### PR TITLE
MySQLdb Patches

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -142,13 +142,6 @@ _mysql_Exception(_mysql_ConnectionObject *c)
 	merr = mysql_errno(&(c->connection));
 	if (!merr)
 		e = _mysql_InterfaceError;
-	else if (merr > CR_MAX_ERROR) {
-		PyTuple_SET_ITEM(t, 0, PyInt_FromLong(-1L));
-		PyTuple_SET_ITEM(t, 1, PyString_FromString("error totally whack"));
-		PyErr_SetObject(_mysql_InterfaceError, t);
-		Py_DECREF(t);
-		return NULL;
-	}
 	else switch (merr) {
 	case CR_COMMANDS_OUT_OF_SYNC:
 	case ER_DB_CREATE_EXISTS:

--- a/_mysql.c
+++ b/_mysql.c
@@ -388,6 +388,7 @@ _mysql_ResultObject_Initialize(
 	int use=0; 
 	PyObject *conv=NULL;
 	int n, i;
+	int field_count;
 	MYSQL_FIELD *fields;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|iO", kwlist,
@@ -400,6 +401,7 @@ _mysql_ResultObject_Initialize(
 	else
 		Py_INCREF(conv);
 
+	field_count = mysql_field_count(&(conn->connection));
 	self->conn = (PyObject *) conn;
 	Py_INCREF(conn);
 	self->use = use;
@@ -411,7 +413,7 @@ _mysql_ResultObject_Initialize(
 	self->result = result;
 	Py_END_ALLOW_THREADS ;
 	if (!result) {
-		if (mysql_field_count(&(conn->connection)) > 0) {
+		if (field_count > 0) {
 		    _mysql_Exception(conn);
 		    return -1;
 		}


### PR DESCRIPTION
Throw an error on killed query instead of returning empty result set and support returning unknown error numbers in the event the client is older than the server